### PR TITLE
fix: resolve pulumi-components dependency to public npm registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -552,7 +552,7 @@
 		},
 		"node_modules/@keetanetwork/pulumi-components": {
 			"version": "1.0.79",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/pulumi-components/1.0.79/ca5c3fdeb6f1a7aef203eb033c813ab41d2a504f",
+			"resolved": "https://registry.npmjs.org/@keetanetwork/pulumi-components/-/pulumi-components-1.0.79.tgz",
 			"integrity": "sha512-TrLuOR44zC5cqB4XmW4UWwogN/djFuaKBlnpNLCUX2fuugosCMc4BYmgd3A0bk9YtLqRT7kdO5c3ydGrtWULng==",
 			"license": "ISC",
 			"dependencies": {


### PR DESCRIPTION
Although commit 08202514977e09e31c19cbcfb3c9f072a07e1c28 changed the .npmrc file to not use the private GitHub NPM registry anymore, the @keetanetwork/pulumi-components still resolved to the private registry. Since it's now open-source and available in the public NPM registry, we can change the package source to that.

Without that change, running `make` in the root of the project would fail because of a 401 Unauthorized error.